### PR TITLE
feat(reports): add maintenance history report and comparison module

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1006,6 +1006,15 @@
 						"description": "Detailed account statements"
 					}
 				}
+			},
+			"bills": {
+				"title": "Bills",
+				"links": {
+					"maintenance": {
+						"label": "Maintenance",
+						"description": "Maintenance history"
+					}
+				}
 			}
 		},
 		"generate": "Generate"

--- a/messages/en/Maintenance.json
+++ b/messages/en/Maintenance.json
@@ -65,5 +65,58 @@
       "createdAt":         "Created at",
       "lastUpdatedBy":     "Last updated by",
       "lastUpdatedAt":     "Last updated at"
+    },
+    "report": {
+      "title": "Maintenance Report",
+      "serial": "Serial Number",
+      "search": "Search",
+      "error404": "No Items linked with this serial number",
+      "table": {
+        "title": "Maintenance history",
+        "serial": "Serial",
+        "filter": "Filter status:",
+        "all": "All",
+        "fields": {
+          "client": "Client",
+          "dateIn": "Date In",
+          "dateOut": "Date Out",
+          "maintenanceDate":"Maintenance Date",
+          "maintainedBy": "Maintained by",
+          "parts": "Parts used",
+          "replacedParts": "Parts replaced",
+          "status": "Status",
+          "malfunctions": "Malfunctions",
+          "notes": "Notes",
+          "item": "Item"
+        },
+        "status": {
+          "pending":     "Pending",
+          "inProgress":  "In Progress",
+          "completed":   "MCompleted",
+          "cancelled":   "Cancelled",
+          "rejected":    "Rejected",
+          "maintained":  "Maintained",
+          "unknown":     "Unknown"
+        },
+        "timeLineChart": {
+          "nothing": "No records to display",
+          "pts": "{pts} pts",
+          "all": "All",
+          "status": "Click points to add them to comparison",
+          "unlimited": "Unlimited",
+          "upTo": "up to {num}"
+        },
+        "table": {
+          "field": "Field",
+          "was": "was {status}",
+          "changed": "changed",
+          "comparison": "Comparison",
+          "unlimited": "Unlimited comparisons",
+          "clear": "Clear all",
+          "des": "Select 2 or more points on the chart to compare their details.",
+          "context": "context (prev)",
+          "selected": "selected"
+        }
+      }
     }
 }

--- a/src/app/[locale]/(protected)/invoice/maintenance/list/page.jsx
+++ b/src/app/[locale]/(protected)/invoice/maintenance/list/page.jsx
@@ -18,7 +18,7 @@ export default async function Items({ searchParams }) {
                 { key: 'limit', default: 12 },
                 { key: 'offset', default: 0 },
                 { key: 'client_name', default: '', searchLabel: t('inputs.search.name') },
-                { key: 'serial_number', default: '', searchLabel: t('inputs.search.serial_number') },
+                { key: 'serial_numbers', default: '', searchLabel: t('inputs.search.serial_number') },
                 { key: 'notes', default: '', searchLabel: t('inputs.search.notes') },
                 { key: 'malfunctions', default: '', searchLabel: t('inputs.search.malfunctions') },
                 { key: 'date_in', default: '', searchLabel: t('inputs.search.date_in') },

--- a/src/app/[locale]/(protected)/reports/(bills)/maintenance-history/[serialNum]/page.jsx
+++ b/src/app/[locale]/(protected)/reports/(bills)/maintenance-history/[serialNum]/page.jsx
@@ -1,0 +1,22 @@
+// import { toast } from "sonner";
+import PageView from "./view"
+import { httpRequest } from "@/utils/HTTPMethods";
+// import { useTranslations } from "next-intl";
+// import { useRouter } from "next/navigation";
+
+async function page({ params }) {
+    // const router = useRouter()
+    const serialNum = (await params).serialNum
+    // const t = useTranslations('maintenance.report');
+    const res = await httpRequest(`api/maintenance/?serial_number=${serialNum}`);
+    // if (handleResponse(res)) return;
+    // if (!res.ok) {
+        // toast.error(t("error404"))
+        // router.back()
+    // }
+    return (
+        <PageView data={res} />
+    )
+}
+
+export default page

--- a/src/app/[locale]/(protected)/reports/(bills)/maintenance-history/[serialNum]/view.jsx
+++ b/src/app/[locale]/(protected)/reports/(bills)/maintenance-history/[serialNum]/view.jsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { ArrowsRightLeftIcon, TrashIcon, FunnelIcon } from "@heroicons/react/24/outline";
+import { parseDate, formatDate } from "@/components/comparing/utils";
+import { StatusBadge, statusMeta } from "@/components/comparing/StatusBadge";
+import { TimelineChart } from "@/components/comparing/TimelineChart";
+import { ComparisonTable } from "@/components/comparing/ComparisonTable";
+import { useTranslations } from "next-intl";
+
+export default function MaintenanceComparisonDashboard({
+  data = [],
+}) {
+  const t = useTranslations("maintenance.report.table");
+  // const defaultStatusStyles = useDefaultStatusStyles();
+  const statusStyles = {
+    mcomplete: {
+      label: t("status.completed"),
+      color: "#10b981", // Emerald Green
+      badge: "bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-600/20 dark:bg-emerald-500/10 dark:text-emerald-400 dark:ring-emerald-500/20",
+    },
+    maintained: {
+      label: t("status.maintained"),
+      color: "#0284c7",
+      badge: "bg-sky-50 text-sky-700 ring-1 ring-inset ring-sky-600/20 dark:bg-sky-500/10 dark:text-sky-400 dark:ring-sky-500/20",
+    },
+    pending: {
+      label: t("status.pending"),
+      color: "#f59e0b", // Warm Amber
+      badge: "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/20 dark:bg-amber-400/10 dark:text-amber-400 dark:ring-amber-400/20",
+    },
+    rejected: {
+      label: t("status.rejected"),
+      color: "#e11d48", // Rose Red
+      badge: "bg-rose-50 text-rose-700 ring-1 ring-inset ring-rose-600/20 dark:bg-rose-500/10 dark:text-rose-400 dark:ring-rose-500/20",
+    },
+  };
+  // const statusStyles = customStatusStyles || defaultStatusStyles;
+  const results = data?.data?.results ?? [];
+  const [selectedIds, setSelectedIds] = useState(() => new Set());
+  const [allowUnlimited, setAllowUnlimited] = useState(false);
+  
+  // 1. Status Filter State (null = show all statuses)
+  const [activeStatusFilter, setActiveStatusFilter] = useState(null);
+
+  const sortedByDate = useMemo(() => {
+    return [...results].sort((a, b) => {
+      const da = parseDate(a.maintenance_date || a.date_in) ?? 0;
+      const db = parseDate(b.maintenance_date || b.date_in) ?? 0;
+      return da - db;
+    });
+  }, [results]);
+
+  // 2. Filter records based on selected status filter
+  const filteredRecords = useMemo(() => {
+    if (!activeStatusFilter) return sortedByDate;
+    return sortedByDate.filter((r) => r.status === activeStatusFilter);
+  }, [sortedByDate, activeStatusFilter]);
+
+  function toggle(record) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(record._hashed_id)) {
+        next.delete(record._hashed_id);
+      } else {
+        if (!allowUnlimited && next.size >= 5) return prev;
+        next.add(record._hashed_id);
+      }
+      return next;
+    });
+  }
+
+  function remove(record) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.delete(record._hashed_id);
+      return next;
+    });
+  }
+
+  function clearAll() {
+    setSelectedIds(new Set());
+  }
+
+  const selectedRecords = sortedByDate.filter((r) => selectedIds.has(r._hashed_id));
+
+  const columns = selectedRecords.map((r) => ({
+    record: r,
+    tag: "selected",
+  }));
+
+  // Passing customStatusStyles down to StatusBadge in render
+  const fields = [
+    { key: "client", label: t("fields.client"), accessor: (r) => r._client_name, ignoreDiff: true },
+    { key: "item", label: "Item", accessor: (r) => r._item_name, ignoreDiff: true },
+    { key: "status", label: "Status", accessor: (r) => r.status, render: (v) => <StatusBadge status={v} customStyles={statusStyles} /> },
+    { key: "date_in", label: t("fields.dateIn"), accessor: (r) => (r.date_in ? formatDate(parseDate(r.date_in)) : null) },
+    { key: "maintenance_date", label: t("fields.maintenanceDate"), accessor: (r) => (r.maintenance_date ? formatDate(parseDate(r.maintenance_date)) : null) },
+    { key: "date_out", label: t("fields.dateOut"), accessor: (r) => (r.date_out ? formatDate(parseDate(r.date_out)) : null) },
+    { key: "maintained_by", label: t("fields.maintainedBy"), accessor: (r) => r._maintained_by_name?.trim() || null },
+    { key: "malfunctions", label: t("fields.malfunctions"), accessor: (r) => r.malfunctions },
+    { key: "notes", label: t("fields.notes"), accessor: (r) => r.notes, ignoreDiff: true },
+    { key: "parts", label: t("fields.parts"), accessor: (r) => r.parts, isList: true },
+  ];
+
+  const firstRecord = sortedByDate[0];
+  const availableStatuses = Object.keys(statusStyles);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-6">
+      <div className="max-w-5xl mx-auto space-y-6">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Maintenance history</h2>
+          {firstRecord && (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {t("serial")} <span className="font-mono"><b>{firstRecord.serial_number}</b></span> · {/* {firstRecord._client_name} */}
+            </p>
+          )}
+        </div>
+
+        {/* Timeline Chart Container */}
+        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+          
+          {/* Status Filter Interactive Bar */}
+          <div className="flex flex-wrap items-center justify-between gap-2 mb-4 pb-3 border-b border-gray-100 dark:border-gray-700">
+            <div className="flex items-center gap-1.5 text-xs font-medium text-gray-500 dark:text-gray-400">
+              <FunnelIcon className="w-3.5 h-3.5" />
+              {t("filter")}
+            </div>
+            
+            <div className="flex flex-wrap items-center gap-1.5">
+              <button
+                onClick={() => setActiveStatusFilter(null)}
+                className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${
+                  activeStatusFilter === null
+                    ? "bg-gray-900 text-white dark:bg-white dark:text-gray-900"
+                    : "bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300"
+                }`}
+              >
+                {t("all")} ({sortedByDate.length})
+              </button>
+
+              {availableStatuses.map((stKey) => {
+                const meta = statusMeta(stKey, statusStyles);
+                const count = sortedByDate.filter((r) => r.status === stKey).length;
+                const isActive = activeStatusFilter === stKey;
+
+                return (
+                  <button
+                    key={stKey}
+                    onClick={() => setActiveStatusFilter(isActive ? null : stKey)}
+                    className={`px-2.5 py-1 rounded-full text-xs font-medium transition-all ${
+                      isActive
+                        ? "ring-2 ring-offset-1 ring-blue-500 shadow-sm"
+                        : "opacity-75 hover:opacity-100"
+                    } ${meta.badge}`}
+                  >
+                    {meta.label} ({count})
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Render Timeline with Filtered Records */}
+          <TimelineChart
+            records={filteredRecords}
+            getId={(r) => r._hashed_id}
+            getDate={(r) => r.maintenance_date || r.date_in}
+            getValue={(r) => r.parts?.length ?? 0}
+            getStatus={(r) => r.status}
+            customStatusStyles={statusStyles}
+            valueLabel="Parts replaced"
+            selectedIds={selectedIds}
+            onToggle={toggle}
+            renderSummary={(r) => [
+              { label: t("fields.item"), value: r._item_name },
+              { label: t("fields.status"), value: statusMeta(r.status, statusStyles).label },
+              { label: t("fields.dateIn"), value: r.date_in ? formatDate(parseDate(r.date_in)) : "—" },
+              { label: t("status.maintained"), value: r.maintenance_date ? formatDate(parseDate(r.maintenance_date)) : "—" },
+              { label: t("fields.dateOut"), value: r.date_out ? formatDate(parseDate(r.date_out)) : "—" },
+              { label: t("fields.maintainedBy"), value: r._maintained_by_name?.trim() || "—" },
+              { label: t("fields.replacedParts"), value: r.parts?.length ?? 0 },
+            ]}
+          />
+
+          <p className="text-xs text-gray-400 dark:text-gray-500 mt-3 flex items-center gap-1">
+            <ArrowsRightLeftIcon className="w-3.5 h-3.5" />
+            {t('timeLineChart.status')} {allowUnlimited ? `(${t('timeLineChart.unlimited')})` : `(${t("timeLineChart.upTo", {num: 5})})`}
+          </p>
+        </div>
+
+        {/* Comparison Table Section */}
+        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+              Comparison {selectedRecords.length > 0 && `(${selectedRecords.length})`}
+            </h3>
+
+            <div className="flex items-center gap-4">
+              <label className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={allowUnlimited}
+                  onChange={(e) => setAllowUnlimited(e.target.checked)}
+                  className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
+                />
+                {t("table.unlimited")}
+              </label>
+
+              {selectedRecords.length > 0 && (
+                <button
+                  onClick={clearAll}
+                  className="inline-flex items-center gap-1 text-xs text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 font-medium"
+                >
+                  <TrashIcon className="w-3.5 h-3.5" />
+                  {t("table.clear")}
+                </button>
+              )}
+            </div>
+          </div>
+
+          {columns.length === 0 ? (
+            <div className="text-sm text-gray-400 dark:text-gray-500 text-center py-8 border border-dashed border-gray-200 dark:border-gray-700 rounded-lg">
+              {t("table.des")}
+            </div>
+          ) : (
+            <ComparisonTable
+              columns={columns}
+              fields={fields}
+              onRemove={remove}
+              getId={(r) => r._hashed_id}
+              maxColumns={allowUnlimited ? undefined : 5}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/(protected)/reports/(bills)/maintenance-history/page.jsx
+++ b/src/app/[locale]/(protected)/reports/(bills)/maintenance-history/page.jsx
@@ -1,0 +1,72 @@
+'use client'
+
+import FormButton from '@/components/FormButton'
+import Form from 'next/form'
+import { redirect, RedirectType } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+import styles from '@/styles/reports/main.module.css'
+import { PermissionGate } from '@/components/PermissionGate'
+import { PERMISSIONS } from '@/config/permissions.config'
+import TextInput from '@/components/inputs/text/TextInput'
+import useGenericResponseHandler from '@/components/custom hooks/useGenericResponseHandler'
+import {useState} from 'react'
+import { httpRequest  } from '@/utils/HTTPMethods'
+import { toast } from 'sonner'
+
+function page() {
+    const handleResponse = useGenericResponseHandler();
+    const [isLoading, setIsLoading] = useState(false);
+
+    const t = useTranslations('maintenance.report');
+
+    const handleSubmit = async (e) => {
+        e.preventDefault()
+
+        const formData = new FormData(e.target);
+        const serialNum = formData.get("serialNum");
+
+        setIsLoading(true);
+        const res = await httpRequest(`api/maintenance/?serial_number=${serialNum}`);
+        console.log(res)
+        if (handleResponse(res)) return;
+        if (res.ok) {
+            if ((res?.data?.count || 0) != 0) {
+                // redirect(`/reports/maintenance-history/${serialNum}`, RedirectType.push);
+            } else {
+                toast.error(t("error404"))
+            }
+        }
+        setIsLoading(false);
+    }
+
+    return (
+        <PermissionGate permission={PERMISSIONS.MAINTENANCE_INVOICES.VIEW}>
+            <div>
+                <Form onSubmit={handleSubmit} className={styles.form}>
+                    <h1 className='text-2xl font-bold mb-2'>{t("title")}</h1>
+                    <TextInput
+                        name="serialNum"
+                        label={t("serial")}
+                        error=''
+                        required
+                    />
+
+                    <FormButton
+                        type="submit"
+                        variant="secondary"
+                        size="md"
+                        bgColor="bg-blue-500 dark:bg-blue-600"
+                        hoverBgColor="bg-blue-700 dark:bg-blue-800"
+                        textColor="text-white dark:text-gray-100"
+                        className="w-full z-0 mt-4"
+                        isLoading={isLoading}
+                    >
+                        {t("search")}
+                    </FormButton>
+                </Form>
+            </div>
+        </PermissionGate>
+    )
+}
+
+export default page

--- a/src/app/[locale]/(protected)/reports/page.jsx
+++ b/src/app/[locale]/(protected)/reports/page.jsx
@@ -110,6 +110,22 @@ async function page({ params }) {
                 }
             ]
         },
+        {
+            title: t("reportSections.bills.title"),
+            icon: ArrowPathIcon,
+            color: "emerald",
+            gradient: "from-emerald-500 to-emerald-600",
+            darkGradient: "dark:from-emerald-600 dark:to-emerald-700",
+            links: [
+                {
+                    href: "/reports/maintenance-history/",
+                    label: t("reportSections.bills.links.maintenance.label"),
+                    description: t("reportSections.bills.links.maintenance.description"),
+                    icon: ArrowPathIcon,
+                    permission: PERMISSIONS.MAINTENANCE_INVOICES.VIEW
+                }
+            ]
+        },
     ];
 
     // Filter sections and their links based on current user's permissions

--- a/src/components/comparing/ComparisonTable.jsx
+++ b/src/components/comparing/ComparisonTable.jsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { parseDate, formatDate, sameValue } from "./utils";
+import { useTranslations } from "next-intl";
+
+/* ============================================================================
+   GENERIC: ComparisonTable
+   ----------------------------------------------------------------------------
+   Turns any set of selected records into a side-by-side diff table, tagging
+   cells that changed vs. the previous column.
+
+   Props
+     columns    – ordered array of { record, tag } where tag is "selected" | "context"
+     fields     – [{ key, label, accessor(record), render?(value, record), isList?, ignoreDiff? }]
+     onRemove   – (record) => void (optional)
+     getId      – (record) => unique id
+     maxColumns – number (optional, e.g. 5)
+   ============================================================================ */
+
+function diffParts(prev = [], next = []) {
+  const key = (p) => p._spare_part_name || String(p.spare_part);
+  const prevMap = new Map(prev.map((p) => [key(p), p]));
+  const nextMap = new Map(next.map((p) => [key(p), p]));
+  const rows = [];
+  Array.from(new Set([...prevMap.keys(), ...nextMap.keys()])).forEach((k) => {
+    const p = prevMap.get(k);
+    const n = nextMap.get(k);
+    if (p && !n) rows.push({ name: k, kind: "removed", qty: p.quantity });
+    else if (!p && n) rows.push({ name: k, kind: "added", qty: n.quantity });
+    else if (p && n && String(p.quantity) !== String(n.quantity))
+      rows.push({ name: k, kind: "changed", qty: n.quantity, prevQty: p.quantity });
+    else if (p && n) rows.push({ name: k, kind: "same", qty: n.quantity });
+  });
+  return rows;
+}
+
+export function ComparisonTable({ columns, fields, onRemove, getId, maxColumns }) {
+  const t = useTranslations("maintenance.report.table.table")
+
+  // Cap columns if maxColumns is provided
+  const visibleColumns = maxColumns ? columns.slice(0, maxColumns) : columns;
+
+  return (
+    <div className="overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg snap-x snap-mandatory scroll-smooth touch-pan-x">
+      <table className="w-full text-sm text-left text-gray-600 dark:text-gray-300 border-collapse">
+        <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+          <tr>
+            {/* Sticky top-left cell gets z-20 to stay above both row headers and column headers when scrolling */}
+            <th
+              scope="col"
+              className="px-3 sm:px-4 py-3 sticky left-0 bg-gray-50 dark:bg-gray-700 z-20 min-w-[110px] sm:min-w-[140px] shadow-[1px_0_0_0_rgba(0,0,0,0.05)] dark:shadow-[1px_0_0_0_rgba(255,255,255,0.05)]"
+            >
+              {t("field")}
+            </th>
+            {visibleColumns.map((col) => (
+              <th
+                key={getId(col.record)}
+                scope="col"
+                className="px-3 sm:px-4 py-3 min-w-[135px] sm:min-w-[160px] md:min-w-[180px] snap-start"
+              >
+                <div className="flex items-center justify-between gap-1.5">
+                  <div className="normal-case">
+                    <div className="font-semibold text-gray-900 dark:text-white text-xs sm:text-sm">
+                      {formatDate(parseDate(col.record.maintenance_date || col.record.date_in))}
+                    </div>
+                    <div className="text-[10px] sm:text-[11px] text-gray-400 font-normal">
+                      {col.tag === "context" ? t("context") : t("selected")}
+                    </div>
+                  </div>
+                  {col.tag === "selected" && onRemove && (
+                    <button
+                      onClick={() => onRemove(col.record)}
+                      className="text-gray-400 hover:text-red-500 p-0.5 rounded"
+                      title="Remove from comparison"
+                    >
+                      <XMarkIcon className="w-3.5 h-3.5" />
+                    </button>
+                  )}
+                </div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {fields.map((field) => (
+            <tr key={field.key} className="bg-white border-b dark:bg-gray-800 dark:border-gray-700 border-gray-200">
+              {/* Sticky first column cell gets z-10 */}
+              <th
+                scope="row"
+                className="px-3 sm:px-4 py-3 font-medium text-gray-900 dark:text-white sticky left-0 bg-white dark:bg-gray-800 z-10 whitespace-nowrap text-xs sm:text-sm shadow-[1px_0_0_0_rgba(0,0,0,0.05)] dark:shadow-[1px_0_0_0_rgba(255,255,255,0.05)]"
+              >
+                {field.label}
+              </th>
+              {visibleColumns.map((col, i) => {
+                const value = field.accessor(col.record);
+                const prevValue = i > 0 ? field.accessor(visibleColumns[i - 1].record) : undefined;
+                
+                // Respect ignoreDiff property
+                const changed = i > 0 && !field.isList && !field.ignoreDiff && !sameValue(value, prevValue);
+
+                if (field.isList) {
+                  const diffRows =
+                    i === 0
+                      ? (value || []).map((p) => ({
+                          name: p._spare_part_name || p.spare_part,
+                          kind: "same",
+                          qty: p.quantity,
+                        }))
+                      : diffParts(prevValue, value);
+                  return (
+                    <td key={getId(col.record)} className="px-3 sm:px-4 py-3 align-top snap-start text-xs sm:text-sm">
+                      {diffRows.length === 0 ? (
+                        <span className="text-gray-400">—</span>
+                      ) : (
+                        <ul className="space-y-0.5">
+                          {diffRows.map((d) => (
+                            <li
+                              key={d.name}
+                              className={
+                                d.kind === "added"
+                                  ? "text-green-600 dark:text-green-400"
+                                  : d.kind === "removed"
+                                  ? "text-red-600 dark:text-red-400 line-through"
+                                  : d.kind === "changed"
+                                  ? "text-amber-600 dark:text-amber-400"
+                                  : "text-gray-600 dark:text-gray-300"
+                              }
+                            >
+                              {d.kind === "added" && "+ "}
+                              {d.kind === "removed" && "− "}
+                              {d.name} × {d.qty}
+                              {d.kind === "changed" && (
+                                <span className="text-gray-400 line-through ml-1">{t("was", {status: d.prevQty})}</span>
+                              )}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </td>
+                  );
+                }
+
+                return (
+                  <td
+                    key={getId(col.record)}
+                    className={`px-3 sm:px-4 py-3 align-top snap-start text-xs sm:text-sm ${
+                      changed ? "bg-amber-50 dark:bg-amber-900/20 border-l-2 border-amber-400" : ""
+                    }`}
+                  >
+                    {field.render ? field.render(value, col.record) : value ?? <span className="text-gray-400">—</span>}
+                    {changed && (
+                      <span className="ml-1.5 inline-block text-[9px] sm:text-[10px] font-semibold uppercase text-amber-600 dark:text-amber-400 align-middle">
+                        {t("changed")}
+                      </span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/comparing/RangeSlider.jsx
+++ b/src/components/comparing/RangeSlider.jsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRef, useState, useCallback } from "react";
+
+/* ============================================================================
+   GENERIC: RangeSlider
+   ----------------------------------------------------------------------------
+   A custom draggable slider — filled track + thumb — used to replace the
+   native <input type="range"> in TimelineChart. Native range inputs jump in
+   steps and feel clunky to drag; this one tracks the pointer continuously
+   and only animates (via CSS transition) when you're *not* actively
+   dragging, so live dragging feels instant and letting go feels smooth.
+
+   Props
+     min, max   – numeric bounds
+     value      – current value (integer)
+     onChange   – (value) => void
+     className  – optional extra classes on the track wrapper
+   ============================================================================ */
+
+export function RangeSlider({ min, max, value, onChange, className = "" }) {
+  const trackRef = useRef(null);
+  const [dragging, setDragging] = useState(false);
+
+  const percent = max > min ? ((value - min) / (max - min)) * 100 : 0;
+
+  const updateFromClientX = useCallback(
+    (clientX) => {
+      const track = trackRef.current;
+      if (!track) return;
+      const rect = track.getBoundingClientRect();
+      const ratio = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width));
+      const raw = min + ratio * (max - min);
+      onChange(Math.round(raw));
+    },
+    [min, max, onChange]
+  );
+
+  function handlePointerDown(e) {
+    e.preventDefault();
+    setDragging(true);
+    trackRef.current?.setPointerCapture?.(e.pointerId);
+    updateFromClientX(e.clientX);
+  }
+
+  function handlePointerMove(e) {
+    if (!dragging) return;
+    updateFromClientX(e.clientX);
+  }
+
+  function handlePointerUp(e) {
+    setDragging(false);
+    trackRef.current?.releasePointerCapture?.(e.pointerId);
+  }
+
+  return (
+    <div
+      ref={trackRef}
+      className={`relative h-5 flex items-center select-none touch-none ${
+        dragging ? "cursor-grabbing" : "cursor-pointer"
+      } ${className}`}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      role="slider"
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={value}
+    >
+      <div className="absolute inset-x-0 h-1.5 rounded-full bg-gray-200 dark:bg-gray-700" />
+      <div
+        className="absolute left-0 h-1.5 rounded-full bg-blue-600"
+        style={{
+          width: `${percent}%`,
+          transition: dragging ? "none" : "width 150ms ease-out",
+        }}
+      />
+      <div
+        className="absolute w-4 h-4 rounded-full bg-blue-600 border-2 border-white dark:border-gray-900 shadow-md"
+        style={{
+          left: `calc(${percent}% - 8px)`,
+          transition: dragging ? "none" : "left 150ms ease-out",
+          transform: dragging ? "scale(1.15)" : "scale(1)",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/comparing/StatusBadge.jsx
+++ b/src/components/comparing/StatusBadge.jsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+// 1. Custom hook for default translated status styles
+export function useDefaultStatusStyles() {
+  // Use "report.table.status" (or "maintenance.report.table.status" depending on your JSON file structure)
+  const t = useTranslations("maintenance.report.table.status");
+
+  return {
+    mcomplete: {
+      label: t("completed"),
+      color: "#16a34a",
+      badge: "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-400",
+    },
+    pending: {
+      label: t("pending"),
+      color: "#d97706",
+      badge: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400",
+    },
+    in_progress: {
+      label: t("inProgress"), // 👈 Fixed: matches "inProgress" in your JSON
+      color: "#2563eb",
+      badge: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-400",
+    },
+    cancelled: {
+      label: t("cancelled"),
+      color: "#dc2626",
+      badge: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400",
+    },
+  };
+}
+
+// 2. Pure helper function to get metadata out of a resolved styles object
+export function statusMeta(status, styles = {}) {
+  return (
+    styles[status] || {
+      label: status || "Unknown",
+      color: "#6b7280",
+      badge: "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300",
+    }
+  );
+}
+
+// 3. Badge Component
+export function StatusBadge({ status, customStyles }) {
+  const defaultStyles = useDefaultStatusStyles();
+  const styles = customStyles || defaultStyles;
+  const meta = statusMeta(status, styles);
+
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${meta.badge}`}>
+      {meta.label}
+    </span>
+  );
+}

--- a/src/components/comparing/TimelineChart.jsx
+++ b/src/components/comparing/TimelineChart.jsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useState, useMemo, useEffect } from "react";
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
+import { WrenchIcon } from "@heroicons/react/24/outline";
+import { parseDate, formatDate, useIsDark } from "./utils";
+import { statusMeta } from "./StatusBadge";
+import { RangeSlider } from "./RangeSlider";
+
+/* ============================================================================
+   GENERIC: TimelineChart
+   ----------------------------------------------------------------------------
+   A scatter timeline with a built-in "show N of M" range slider + click-to-
+   select dots + hover tooltip. Feed it any array + accessor functions.
+
+   Props
+     records       – array of source records (any shape)
+     getId(r)      – unique id for a record
+     getDate(r)    – date string/ms used for the x-axis
+     getValue(r)   – number used for the y-axis
+     getStatus(r)  – optional, drives dot color + a small legend
+     valueLabel    – y-axis label
+     renderSummary(r) – (record) => [{ label, value }] shown on hover
+     selectedIds   – Set of currently-selected ids
+     onToggle(r)   – called when a dot is clicked
+     title         – optional heading above the chart
+
+   To reuse for something else (e.g. comparing invoices, comparing
+   inspection reports), import this component unchanged and pass new
+   accessor functions.
+   ============================================================================ */
+
+export function TimelineChart({
+  records,
+  getId,
+  getDate,
+  getValue,
+  getStatus,
+  customStatusStyles,
+  valueLabel = "Value",
+  renderSummary,
+  selectedIds,
+  onToggle,
+  title,
+}) {
+  const isDark = useIsDark();
+  const gridColor = isDark ? "#374151" : "#e5e7eb";
+  const axisColor = isDark ? "#9ca3af" : "#6b7280";
+  const tooltipBg = isDark ? "#1f2937" : "#ffffff";
+  const tooltipBorder = isDark ? "#374151" : "#e5e7eb";
+  const tooltipText = isDark ? "#f9fafb" : "#111827";
+
+  // Allow windowSize to be a number or "all"
+  const [windowSize, setWindowSize] = useState(15);
+
+  const sorted = useMemo(() => {
+    return [...records]
+      .map((r) => ({ record: r, ts: parseDate(getDate(r)) }))
+      .filter((r) => r.ts !== null)
+      .sort((a, b) => a.ts - b.ts);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [records]);
+
+  // Determine active display size
+  const activeWindowSize = windowSize === "all" ? sorted.length : Number(windowSize);
+
+  const [startIndex, setStartIndex] = useState(() =>
+    Math.max(0, sorted.length - activeWindowSize)
+  );
+
+  useEffect(() => {
+    setStartIndex((s) => Math.min(s, Math.max(0, sorted.length - activeWindowSize)));
+  }, [activeWindowSize, sorted.length]);
+
+  const maxStart = Math.max(0, sorted.length - activeWindowSize);
+  const isWindowed = sorted.length > activeWindowSize;
+  const visible = isWindowed
+    ? sorted.slice(startIndex, startIndex + activeWindowSize)
+    : sorted;
+  const step = Math.max(1, Math.floor(activeWindowSize / 2));
+
+  const chartData = visible.map(({ record, ts }) => ({
+    x: ts,
+    y: getValue(record),
+    record,
+  }));
+
+  const statusesPresent = getStatus
+    ? Array.from(new Set(sorted.map((s) => getStatus(s.record))))
+    : [];
+
+  function CustomDot(props) {
+    const { cx, cy, payload } = props;
+    if (cx == null || cy == null) return null;
+    const id = getId(payload.record);
+    const isSelected = selectedIds?.has(id);
+    const color = getStatus ? statusMeta(getStatus(payload.record), customStatusStyles).color : "#2563eb"; return (
+      <g
+        style={{ cursor: onToggle ? "pointer" : "default" }}
+        onClick={() => onToggle?.(payload.record)}
+      >
+        {isSelected && <circle cx={cx} cy={cy} r={11} fill={color} opacity={0.2} />}
+        <circle
+          cx={cx}
+          cy={cy}
+          r={isSelected ? 7 : 5.5}
+          fill={color}
+          stroke={isSelected ? color : isDark ? "#111827" : "#ffffff"}
+          strokeWidth={isSelected ? 2 : 1.5}
+        />
+      </g>
+    );
+  }
+
+  function CustomTooltip({ active, payload }) {
+    if (!active || !payload?.length) return null;
+    const record = payload[0].payload.record;
+    const rows = renderSummary ? renderSummary(record) : [];
+    return (
+      <div
+        className="rounded-md border px-3 py-2 shadow-lg text-xs"
+        style={{
+          background: tooltipBg,
+          borderColor: tooltipBorder,
+          color: tooltipText,
+          minWidth: 190,
+        }}
+      >
+        {rows.map((row) => (
+          <div key={row.label} className="flex justify-between gap-4 py-0.5">
+            <span className="opacity-60">{row.label}</span>
+            <span className="font-medium text-right">{row.value ?? "—"}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      {title && (
+        <div className="flex items-center gap-2 mb-3">
+          <WrenchIcon className="w-4 h-4 text-gray-400" />
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">{title}</h3>
+        </div>
+      )}
+
+      {sorted.length === 0 ? (
+        <div className="text-sm text-gray-400 dark:text-gray-500 text-center py-10 border border-dashed border-gray-200 dark:border-gray-700 rounded-lg">
+          No records to display
+        </div>
+      ) : (
+        <>
+          <ResponsiveContainer width="100%" height={280}>
+            <ScatterChart margin={{ top: 10, right: 20, bottom: 10, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
+              <XAxis
+                type="number"
+                dataKey="x"
+                domain={["dataMin", "dataMax"]}
+                tickFormatter={formatDate}
+                stroke={axisColor}
+                tick={{ fill: axisColor, fontSize: 11 }}
+              />
+              <YAxis
+                type="number"
+                dataKey="y"
+                allowDecimals={false}
+                stroke={axisColor}
+                tick={{ fill: axisColor, fontSize: 11 }}
+                width={36}
+                label={{
+                  value: valueLabel,
+                  angle: -90,
+                  position: "insideLeft",
+                  fill: axisColor,
+                  fontSize: 11,
+                }}
+              />
+              <Tooltip
+                content={<CustomTooltip />}
+                cursor={{ strokeDasharray: "3 3", stroke: axisColor }}
+              />
+              <Scatter data={chartData} shape={CustomDot} isAnimationActive={false} />
+            </ScatterChart>
+          </ResponsiveContainer>
+
+          {/* Controls section remains rendered whenever records exist */}
+          <div className="flex items-center gap-3 mt-1 px-1">
+            {isWindowed ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => setStartIndex((s) => Math.max(0, s - step))}
+                  disabled={startIndex === 0}
+                  className="p-1 rounded border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 disabled:opacity-30 hover:bg-gray-50 dark:hover:bg-gray-700"
+                >
+                  <ChevronLeftIcon className="w-4 h-4" />
+                </button>
+
+                <RangeSlider
+                  min={0}
+                  max={maxStart}
+                  value={startIndex}
+                  onChange={setStartIndex}
+                  className="flex-1"
+                />
+
+                <button
+                  type="button"
+                  onClick={() => setStartIndex((s) => Math.min(maxStart, s + step))}
+                  disabled={startIndex >= maxStart}
+                  className="p-1 rounded border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 disabled:opacity-30 hover:bg-gray-50 dark:hover:bg-gray-700"
+                >
+                  <ChevronRightIcon className="w-4 h-4" />
+                </button>
+              </>
+            ) : (
+              /* Spacer to push select & label to the right when full chart is showing */
+              <div className="flex-1" />
+            )}
+
+            <select
+              value={windowSize}
+              onChange={(e) => {
+                const val = e.target.value;
+                setWindowSize(val === "all" ? "all" : Number(val));
+              }}
+              className="text-xs rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 px-1.5 py-1"
+            >
+              {[10, 15, 20, 30].map((n) => (
+                <option key={n} value={n}>
+                  {n} pts
+                </option>
+              ))}
+              <option value="all">All</option>
+            </select>
+
+            <span className="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">
+              {isWindowed
+                ? `${startIndex + 1}–${Math.min(
+                  startIndex + activeWindowSize,
+                  sorted.length
+                )} of ${sorted.length}`
+                : `Showing all ${sorted.length}`}
+            </span>
+          </div>
+
+          {statusesPresent.length > 0 && (
+            <div className="flex flex-wrap gap-3 mt-3 px-1">
+
+              {statusesPresent.map((s) => {
+                const meta = statusMeta(s, customStatusStyles);
+                return (
+                  <span
+                    key={s}
+                    className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400"
+                  >
+                    <span
+                      className="w-2.5 h-2.5 rounded-full inline-block"
+                      style={{ background: meta.color }}
+                    />
+                    {meta.label}
+                  </span>
+                );
+              })}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/comparing/utils.js
+++ b/src/components/comparing/utils.js
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+/* ============================================================================
+   Shared helpers used by TimelineChart, ComparisonTable, and StatusBadge.
+   ============================================================================ */
+
+export function parseDate(value) {
+  if (!value) return null;
+  const t = new Date(value).getTime();
+  return Number.isNaN(t) ? null : t;
+}
+
+export function formatDate(ts) {
+  if (!ts) return "—";
+  return new Date(ts).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "2-digit",
+  });
+}
+
+export function sameValue(a, b) {
+  const norm = (v) => (v === null || v === undefined || v === "" ? "—" : String(v).trim().toLowerCase());
+  return norm(a) === norm(b);
+}
+
+// Detects dark mode via the user's system preference.
+export function useIsDark() {
+  const [isDark, setIsDark] = useState(() =>
+    typeof window !== "undefined" && window.matchMedia
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+      : false
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = (e) => setIsDark(e.matches);
+    mql.addEventListener?.("change", handler);
+    return () => mql.removeEventListener?.("change", handler);
+  }, []);
+
+  return isDark;
+}


### PR DESCRIPTION
Implement an interactive maintenance history report by serial number, featuring a Recharts scatter timeline chart, status filter bar, and side-by-side field diff table.

---

[ API Data / Page ]
       │
       ▼
<MaintenanceComparisonDashboard />
       ├──► Status Filter Bar (filters records by status)
       ├──► <TimelineChart /> (renders scatter plot colored by status)
       └──► <ComparisonTable /> (side-by-side record diff matrix)

- `MaintenanceComparisonDashboard.jsx`: Orchestrator managing selection state & filters.
- `TimelineChart.jsx`: Scatter plot timeline with built-in range slider.
- `ComparisonTable.jsx`: Sticky-column comparison matrix with auto-diff highlighting.
- `StatusBadge.jsx`: i18n-aware status pills and `useDefaultStatusStyles` hook.
- `RangeSlider.jsx`: Range slider component for chart viewport windowing.

1. CUSTOM STATUS STYLES: Pass a `customStatusStyles` prop to `<MaintenanceComparisonDashboard />` to override or add statuses: ```javascript const statusStyles = { mcomplete: { label: t("status.completed"), color: "#10b981", badge: "bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-600/20 dark:bg-emerald-500/10 dark:text-emerald-400", }, // Add extra status keys matching backend status string values };

```

2. EDITING TABLE FIELDS:
Update the `fields` array inside `MaintenanceComparisonDashboard.jsx`:
```javascript
{ key: "date_in", label: t("fields.dateIn"), accessor: (r) => formatDate(r.date_in) } { key: "notes", label: t("fields.notes"), accessor: (r) => r.notes, ignoreDiff: true }

```